### PR TITLE
Хотфикс: Исправление наложений текста в строках при предпросмотре отчёта по изменениям заказа

### DIFF
--- a/Vodovoz/Reports/Orders/OrderChangesReport.rdl
+++ b/Vodovoz/Reports/Orders/OrderChangesReport.rdl
@@ -433,6 +433,7 @@
                         <PaddingTop>1pt</PaddingTop>
                         <VerticalAlign>Middle</VerticalAlign>
                       </Style>
+                      <CanGrow >true</CanGrow>
                     </Textbox>
                   </ReportItems>
                 </TableCell>
@@ -452,6 +453,7 @@
                         <PaddingTop>1pt</PaddingTop>
                         <VerticalAlign>Middle</VerticalAlign>
                       </Style>
+                      <CanGrow >true</CanGrow>
                     </Textbox>
                   </ReportItems>
                 </TableCell>
@@ -586,6 +588,7 @@
                         <PaddingTop>1pt</PaddingTop>
                         <VerticalAlign>Middle</VerticalAlign>
                       </Style>
+                      <CanGrow >true</CanGrow>
                     </Textbox>
                   </ReportItems>
                 </TableCell>
@@ -643,6 +646,7 @@
                         <BorderWidth />
                         <VerticalAlign>Middle</VerticalAlign>
                       </Style>
+                      <CanGrow >true</CanGrow>
                     </Textbox>
                   </ReportItems>
                 </TableCell>


### PR DESCRIPTION
При формировании отчёта по изменениям заказа при доставке в окне просмотра отчёта в рамках одной ячейки строки наслаивались друг на друга.