### PR TITLE
5988 Повторные продажи в ЧЗ по групповому коду

### DIFF
--- a/Source/Libraries/Core/Backend/Edo/Edo.Common/ISaveCodesService.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Common/ISaveCodesService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.TrueMark.TrueMarkProductCodes;
 
 namespace Edo.Common
 {
@@ -8,5 +9,13 @@ namespace Edo.Common
 	{
 		Task SaveCodesToPool(SaveCodesEdoTask edoTask, CancellationToken cancellationToken);
 		Task SaveCodesToPool(ReceiptEdoTask receiptEdoTask, CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Сохраняет код ЧЗ товара в пул кодов
+		/// </summary>
+		/// <param name="productCode">Код ЧЗ товара</param>
+		/// <param name="cancellationToken">Токен отмены</param>
+		/// <returns></returns>
+		Task SaveCodeToPool(TrueMarkProductCode productCode, CancellationToken cancellationToken);
 	}
 }

--- a/Source/Libraries/Core/Backend/Edo/Edo.Common/SaveCodesService.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Common/SaveCodesService.cs
@@ -48,10 +48,25 @@ namespace Edo.Common
 					continue;
 				}
 
-				await _trueMarkCodesPool.PutCodeAsync(productCode.SourceCode.Id, cancellationToken);
-				productCode.ResultCode = null;
-				productCode.SourceCodeStatus = SourceProductCodeStatus.SavedToPool;
+				await SaveCodeToPool(productCode, cancellationToken);
 			}
+		}
+
+		public async Task SaveCodeToPool(TrueMarkProductCode productCode, CancellationToken cancellationToken)
+		{
+			if(productCode.SourceCode is null)
+			{
+				throw new InvalidOperationException("Source code is null");
+			}
+
+			if(productCode.Problem != ProductCodeProblem.None)
+			{
+				throw new InvalidOperationException("Product code has a problem");
+			}
+
+			await _trueMarkCodesPool.PutCodeAsync(productCode.SourceCode.Id, cancellationToken);
+			productCode.ResultCode = null;
+			productCode.SourceCodeStatus = SourceProductCodeStatus.SavedToPool;
 		}
 	}
 }

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/ForOwnNeedsReceiptEdoTaskHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/ForOwnNeedsReceiptEdoTaskHandler.cs
@@ -875,11 +875,10 @@ namespace Edo.Receipt.Dispatcher
 			// Сохранение остатков в пул
 			foreach(var unprocessedCode in unprocessedCodes)
 			{
-				if(unprocessedCode.ProductCode.SourceCode != null)
+				if(unprocessedCode.ProductCode.SourceCode != null
+					&& unprocessedCode.ProductCode.Problem == ProductCodeProblem.None)
 				{
-					await _trueMarkCodesPool.PutCodeAsync(unprocessedCode.ProductCode.SourceCode.Id, cancellationToken);
-					unprocessedCode.ProductCode.SourceCodeStatus = SourceProductCodeStatus.SavedToPool;
-					unprocessedCode.ProductCode.ResultCode = null;
+					await _saveCodesService.SaveCodeToPool(unprocessedCode.ProductCode, cancellationToken);
 				}
 
 				receiptEdoTask.Items.Remove(unprocessedCode);

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/ForOwnNeedsReceiptEdoTaskHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/ForOwnNeedsReceiptEdoTaskHandler.cs
@@ -659,6 +659,21 @@ namespace Edo.Receipt.Dispatcher
 						continue;
 					}
 
+					// проверяем, что стоимость за единицу товара для группового кода можно
+					// получить без остатка (до копеек). Если нет, то не объединяем строки заказа под
+					// групповой код на этом OrderItem, продолжаем искать другой подходящий OrderItem
+					var pricePerItemForGroupCode = Math.Round(orderItem.Price, 2);
+					var groupCodeNetSum =
+						pricePerItemForGroupCode * individualCodesInGroupCount
+						- expandedOrderItemsForOrderItemList
+							.Take(individualCodesInGroupCount)
+							.Sum(x => x.DiscountPerSingleItem);
+
+					if(!CanSplitGroupEvenly(groupCodeNetSum, individualCodesInGroupCount))
+					{
+						continue;
+					}
+
 					var inventPosition = CreateInventPosition(orderItem);
 
 					// i использовать не надо, цикл нужен только для того чтобы прибавить позиции
@@ -708,7 +723,7 @@ namespace Edo.Receipt.Dispatcher
 			// без жесткой привязки к конкретному OrderItem
 			// но в InventPosition будет указан только первый OrderItem
 
-			foreach(var remainGroupCodeItem in groupCodesWithTaskItems)
+			foreach(var remainGroupCodeItem in groupCodesWithTaskItems.ToList())
 			{
 				var groupCode = remainGroupCodeItem.Key;
 				var individualCodesInGroupCount = remainGroupCodeItem.Value.Count();
@@ -737,6 +752,24 @@ namespace Edo.Receipt.Dispatcher
 
 				var orderItemsForInventoryPositionDiscountsSum =
 					orderItemsForInventoryPosition.Sum(x => x.DiscountPerSingleItem);
+
+				// проверяем, что чистую стоимость за единицу товара для группового кода можно
+				// получить без остатка (до копеек). Если нет, то не объединяем строки заказа под
+				// групповой код: дезагрегируем его, входящие штучные коды возвращаем в пул, а строки
+				// заказа уйдут в индивидуальную обработку с подбором недостающих кодов из пула
+				var groupCodeNetSum =
+					orderItemsForInventoryPositionPricesSum - orderItemsForInventoryPositionDiscountsSum;
+
+				if(!CanSplitGroupEvenly(groupCodeNetSum, individualCodesInGroupCount))
+				{
+					// групповой код нельзя использовать в чеке: дезагрегируем его, а входящие штучные
+					// коды возвращаем в общий список необработанных (эти коды были удалены из unprocessedCodes в методе TakeGroupCodesWithTaskItems)
+					// Строки заказа при этом уйдут в индивидуальную обработку с подбором недостающих кодов из пула
+					await _trueMarkWaterCodeService.DisaggregateRelatedCodesAsync(_uow, groupCode, cancellationToken);
+					unprocessedCodes.AddRange(remainGroupCodeItem.Value);
+					groupCodesWithTaskItems.Remove(groupCode);
+					continue;
+				}
 
 				//Округляем цену за единицу до копееек в большую стороную. Далее при необходимости увеличим сумму скидки
 				var pricePerItem = Math.Ceiling(100 * orderItemsForInventoryPositionPricesSum / individualCodesInGroupCount) / 100;
@@ -845,7 +878,10 @@ namespace Edo.Receipt.Dispatcher
 				if(unprocessedCode.ProductCode.SourceCode != null)
 				{
 					await _trueMarkCodesPool.PutCodeAsync(unprocessedCode.ProductCode.SourceCode.Id, cancellationToken);
+					unprocessedCode.ProductCode.SourceCodeStatus = SourceProductCodeStatus.SavedToPool;
+					unprocessedCode.ProductCode.ResultCode = null;
 				}
+
 				receiptEdoTask.Items.Remove(unprocessedCode);
 				await _uow.DeleteAsync(unprocessedCode, cancellationToken);
 			}
@@ -859,7 +895,24 @@ namespace Edo.Receipt.Dispatcher
 					await _uow.DeleteAsync(groupCodeTaskItem, cancellationToken);
 				}
 			}
-		}		
+		}
+
+		/// <summary>
+		/// Определяет, можно ли получить чистую стоимость за единицу товара для группового кода
+		/// без остатка (с точностью до копеек). Если нет, то товары нельзя объединять в одну
+		/// строку чека под этот групповой код
+		/// </summary>
+		/// <param name="netSum">Чистая стоимость строки чека (цена * кол-во - скидка)</param>
+		/// <param name="quantity">Количество товаров, покрываемых групповым кодом</param>
+		private static bool CanSplitGroupEvenly(decimal netSum, decimal quantity)
+		{
+			if(quantity <= 0)
+			{
+				return false;
+			}
+
+			return (netSum * 100m) % quantity == 0;
+		}
 
 		private async Task<IDictionary<TrueMarkWaterGroupCode, IEnumerable<EdoTaskItem>>> TakeGroupCodesWithTaskItems(
 			List<EdoTaskItem> unprocessedTaskItems,

--- a/Source/Tests/Edo/Receipt.Dispatcher.Tests/CreateMarkedFiscalDocumentsTests.cs
+++ b/Source/Tests/Edo/Receipt.Dispatcher.Tests/CreateMarkedFiscalDocumentsTests.cs
@@ -768,7 +768,6 @@ namespace Receipt.Dispatcher.Tests
 				.GetGroupCode(Arg.Any<int>(), Arg.Any<CancellationToken>())
 				.Returns(callInfo => Task.FromResult(
 					_waterGroupCodeRepository.Data.FirstOrDefault(x => x.Id == (int)callInfo[0])));
-			var saveCodesService = Substitute.For<ISaveCodesService>();
 			var bus = Substitute.For<IBus>();
 			var edoCancellationService = new EdoCancellationService(
 				Substitute.For<ILogger<EdoCancellationService>>(),
@@ -778,6 +777,9 @@ namespace Receipt.Dispatcher.Tests
 				Substitute.For<IPublishEndpoint>());
 			var trueMarkWaterCodeService = Substitute.For<ITrueMarkWaterCodeService>();
 			_trueMarkCodesPool = Substitute.For<ReceiptTrueMarkCodesPool>(unitOfWork);
+			var saveCodesService = new SaveCodesService(
+				Substitute.For<ILogger<SaveCodesService>>(),
+				_trueMarkCodesPool);
 
 			return new ForOwnNeedsReceiptEdoTaskHandler(
 				logger,

--- a/Source/Tests/Edo/Receipt.Dispatcher.Tests/CreateMarkedFiscalDocumentsTests.cs
+++ b/Source/Tests/Edo/Receipt.Dispatcher.Tests/CreateMarkedFiscalDocumentsTests.cs
@@ -16,16 +16,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using TrueMark.Codes.Pool;
 using TrueMark.Library;
 using TrueMarkApi.Client;
 using Vodovoz.Core.Data.Repositories;
+using Vodovoz.Core.Domain.Cash;
 using Vodovoz.Core.Domain.Clients;
 using Vodovoz.Core.Domain.Documents;
 using Vodovoz.Core.Domain.Edo;
 using Vodovoz.Core.Domain.Goods;
 using Vodovoz.Core.Domain.Orders;
+using Vodovoz.Core.Domain.Organizations;
 using Vodovoz.Core.Domain.Repositories;
 using Vodovoz.Core.Domain.TrueMark;
 using Vodovoz.Core.Domain.TrueMark.TrueMarkProductCodes;
@@ -39,6 +42,7 @@ namespace Receipt.Dispatcher.Tests
 	{
 		private GenericRepositoryFixture<TrueMarkWaterGroupCode> _waterGroupCodeRepository;
 		private ForOwnNeedsReceiptEdoTaskHandler _forOwnNeedsReceiptEdoTaskHandler;
+		private ReceiptTrueMarkCodesPool _trueMarkCodesPool;
 
 		public CreateMarkedFiscalDocumentsTests()
 		{
@@ -94,7 +98,8 @@ namespace Receipt.Dispatcher.Tests
 					1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 				});
 
-			var mainFiscalDocument = new EdoFiscalDocument();
+			var mainFiscalDocument = new EdoFiscalDocument { Index = 0 };
+			receiptEdoTask.FiscalDocuments.Add(mainFiscalDocument);
 
 			// Act
 
@@ -164,7 +169,8 @@ namespace Receipt.Dispatcher.Tests
 					1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 				});
 
-			var mainFiscalDocument = new EdoFiscalDocument();
+			var mainFiscalDocument = new EdoFiscalDocument { Index = 0 };
+			receiptEdoTask.FiscalDocuments.Add(mainFiscalDocument);
 
 			// Act
 
@@ -234,7 +240,8 @@ namespace Receipt.Dispatcher.Tests
 					1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 				});
 
-			var mainFiscalDocument = new EdoFiscalDocument();
+			var mainFiscalDocument = new EdoFiscalDocument { Index = 0 };
+			receiptEdoTask.FiscalDocuments.Add(mainFiscalDocument);
 
 			// Act
 
@@ -260,6 +267,236 @@ namespace Receipt.Dispatcher.Tests
 				x => Assert
 					.DoesNotContain(x, receiptEdoTask.FiscalDocuments
 					.SelectMany(x => x.InventPositions.Select(x => x.EdoTaskItem.ProductCode.ResultCode.Gtin))));
+		}
+
+		// Если чистую стоимость за единицу товара для группового кода нельзя получить без остатка (до копеек),
+		// групповой код не должен использоваться: товары становятся отдельными строками чека,
+		// а входящие в групповой код штучные коды возвращаются в пул
+		[Fact]
+		public async Task CreateMarkedFiscalDocuments_ShouldNotGroupAndReturnGroupCodeToPool_WhenNetSumPerItemHasRemainder()
+		{
+			// Arrange
+
+			var receiptEdoTask = CreateTestReceiptEdoTaskForTest(
+				// Nomenclatures
+				new (IEnumerable<int> gtinIds, IEnumerable<int> groupGtinIds, bool isAccountableInTrueMark)[]
+				{
+					(new [] { 1, 2 }, new [] { 1, 2 }, true),
+					(Array.Empty<int>(), Array.Empty<int>(), false)
+				},
+				// OrderItems: 11 шт по 30 руб без скидки + 1 шт по 30 руб со скидкой 29 руб.
+				// Чистая сумма 11*30 + (30-29) = 331 руб не делится на 12 без остатка (331/12 = 27,58(3))
+				new (int nomenclatureId, decimal count, decimal price, decimal discount)[]
+				{
+					(1, 11m, 30m, 0m),
+					(1, 1m, 30m, 29m)
+				},
+				// Identification Codes: 1-12 входят в групповой код, 13-24 — штучные для индивидуальной обработки
+				new (bool isInValid, int gtinId)[]
+				{
+					(false, 1), (false, 1), (false, 1), (false, 1), (false, 1), (false, 1),
+					(false, 1), (false, 1), (false, 1), (false, 1), (false, 1), (false, 1),
+					(false, 1), (false, 1), (false, 1), (false, 1), (false, 1), (false, 1),
+					(false, 1), (false, 1), (false, 1), (false, 1), (false, 1), (false, 1),
+				},
+				// Group Codes
+				new (int? parentWaterCodeId, int groupGtinId, bool isInValid, IEnumerable<int> childWaterCodeIds)[]
+				{
+					(null, 1, false, new []{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }),
+				},
+				// Edo Task Item Identification Codes
+				new[]
+				{
+					1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+					13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+				});
+
+			var mainFiscalDocument = new EdoFiscalDocument { Index = 0 };
+			receiptEdoTask.FiscalDocuments.Add(mainFiscalDocument);
+
+			// Act
+
+			await _forOwnNeedsReceiptEdoTaskHandler.UpdateMarkedFiscalDocuments(receiptEdoTask, mainFiscalDocument, default);
+
+			// Assert
+
+			var inventPositions = receiptEdoTask.FiscalDocuments.SelectMany(x => x.InventPositions).ToList();
+
+			// групповой код не должен использоваться ни в одной строке чека
+			Assert.All(inventPositions, x => Assert.Null(x.GroupCode));
+
+			// все 12 единиц товара стали отдельными строками чека с индивидуальными кодами
+			Assert.Equal(12, inventPositions.Count);
+			Assert.All(inventPositions, x => Assert.Equal(1m, x.Quantity));
+			Assert.All(inventPositions, x => Assert.NotNull(x.EdoTaskItem));
+
+			// итоговое количество и стоимость соответствуют исходному заказу
+			Assert.Equal(
+				receiptEdoTask.FormalEdoRequest.Order.OrderItems.Where(x => x.Nomenclature.IsAccountableInTrueMark).Sum(x => x.Count),
+				inventPositions.Sum(x => x.Quantity));
+
+			Assert.Equal(
+				receiptEdoTask.FormalEdoRequest.Order.OrderItems
+					.Where(x => x.Nomenclature.IsAccountableInTrueMark && x.Count > 0)
+					.Sum(x => x.Sum),
+				inventPositions.Sum(x => x.Price * x.Quantity - x.DiscountSum));
+
+			// входящие в отклонённый групповой код 12 штучных кодов возвращены в пул
+			await _trueMarkCodesPool.Received(12).PutCodeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+		}
+
+		// Проверка расформирования группы, один групповой код в одной строке заказа: количества в строке заказа
+		// хватает ровно на один групповой код, но сумма скидки такова, что чистую стоимость за единицу
+		// нельзя получить без остатка (до копеек). Групповой код не применяется — товары становятся
+		// отдельными строками чека, а входящие в него штучные коды возвращаются в пул
+		[Fact]
+		public async Task CreateMarkedFiscalDocuments_ShouldNotApplyGroupCodeToSingleOrderItem_WhenDiscountMakesNetSumPerItemHaveRemainder()
+		{
+			// Arrange
+
+			var receiptEdoTask = CreateTestReceiptEdoTaskForTest(
+				// Nomenclatures
+				new (IEnumerable<int> gtinIds, IEnumerable<int> groupGtinIds, bool isAccountableInTrueMark)[]
+				{
+					(new [] { 1, 2 }, new [] { 1, 2 }, true),
+					(Array.Empty<int>(), Array.Empty<int>(), false)
+				},
+				// OrderItems: 3 шт по 10 руб со скидкой 1 руб на строку.
+				// Скидка распределяется по единицам как [0,3; 0,3; 0,4].
+				// Чистая сумма 3*10 - 1 = 29 руб не делится на 3 без остатка (29/3 = 9,66(6))
+				new (int nomenclatureId, decimal count, decimal price, decimal discount)[]
+				{
+					(1, 3m, 10m, 1m)
+				},
+				// Identification Codes: 1-3 входят в групповой код, 4-6 — штучные для индивидуальной обработки
+				new (bool isInValid, int gtinId)[]
+				{
+					(false, 1), (false, 1), (false, 1),
+					(false, 1), (false, 1), (false, 1),
+				},
+				// Group Codes
+				new (int? parentWaterCodeId, int groupGtinId, bool isInValid, IEnumerable<int> childWaterCodeIds)[]
+				{
+					(null, 1, false, new []{ 1, 2, 3 }),
+				},
+				// Edo Task Item Identification Codes
+				new[]
+				{
+					1, 2, 3, 4, 5, 6
+				});
+
+			var mainFiscalDocument = new EdoFiscalDocument { Index = 0 };
+			receiptEdoTask.FiscalDocuments.Add(mainFiscalDocument);
+
+			// Act
+
+			await _forOwnNeedsReceiptEdoTaskHandler.UpdateMarkedFiscalDocuments(receiptEdoTask, mainFiscalDocument, default);
+
+			// Assert
+
+			var inventPositions = receiptEdoTask.FiscalDocuments.SelectMany(x => x.InventPositions).ToList();
+
+			// групповой код не применён ни в одной строке чека
+			Assert.All(inventPositions, x => Assert.Null(x.GroupCode));
+
+			// все 3 единицы товара стали отдельными строками чека с индивидуальными кодами
+			Assert.Equal(3, inventPositions.Count);
+			Assert.All(inventPositions, x => Assert.Equal(1m, x.Quantity));
+			Assert.All(inventPositions, x => Assert.NotNull(x.EdoTaskItem));
+
+			// итоговое количество и стоимость соответствуют исходному заказу
+			Assert.Equal(
+				receiptEdoTask.FormalEdoRequest.Order.OrderItems.Where(x => x.Nomenclature.IsAccountableInTrueMark).Sum(x => x.Count),
+				inventPositions.Sum(x => x.Quantity));
+
+			Assert.Equal(
+				receiptEdoTask.FormalEdoRequest.Order.OrderItems
+					.Where(x => x.Nomenclature.IsAccountableInTrueMark && x.Count > 0)
+					.Sum(x => x.Sum),
+				inventPositions.Sum(x => x.Price * x.Quantity - x.DiscountSum));
+
+			// входящие в отклонённый групповой код 3 штучных кода возвращены в пул
+			await _trueMarkCodesPool.Received(3).PutCodeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+		}
+
+		// Проверка расформирования группы, два групповых кода в одной строке заказа: количества хватает на два
+		// групповых кода, но по сумме скидки без остатка можно применить только один. Один групповой
+		// код применяется (объединённая строка чека на 3 единицы), второй отклоняется — его товары
+		// становятся отдельными строками, а входящие в него штучные коды возвращаются в пул
+		[Fact]
+		public async Task CreateMarkedFiscalDocuments_ShouldApplyOnlyOneOfTwoGroupCodesToSingleOrderItem_WhenSecondGroupNetSumPerItemHasRemainder()
+		{
+			// Arrange
+
+			var receiptEdoTask = CreateTestReceiptEdoTaskForTest(
+				// Nomenclatures
+				new (IEnumerable<int> gtinIds, IEnumerable<int> groupGtinIds, bool isAccountableInTrueMark)[]
+				{
+					(new [] { 1, 2 }, new [] { 1, 2 }, true),
+					(Array.Empty<int>(), Array.Empty<int>(), false)
+				},
+				// OrderItems: 6 шт по 10 руб со скидкой 1 руб на строку.
+				// Скидка распределяется по единицам как [0,2; 0,2; 0,2; 0,2; 0,2; 0,0].
+				// Первый групповой код (первые 3 единицы): чистая сумма 30 - 0,6 = 29,4 делится на 3 (9,8) — применяется.
+				// Второй групповой код (оставшиеся 3 единицы): чистая сумма 30 - 0,4 = 29,6 не делится на 3 — отклоняется.
+				new (int nomenclatureId, decimal count, decimal price, decimal discount)[]
+				{
+					(1, 6m, 10m, 1m)
+				},
+				// Identification Codes: 1-3 и 4-6 входят в два групповых кода, 7-9 — штучные
+				new (bool isInValid, int gtinId)[]
+				{
+					(false, 1), (false, 1), (false, 1),
+					(false, 1), (false, 1), (false, 1),
+					(false, 1), (false, 1), (false, 1),
+				},
+				// Group Codes
+				new (int? parentWaterCodeId, int groupGtinId, bool isInValid, IEnumerable<int> childWaterCodeIds)[]
+				{
+					(null, 1, false, new []{ 1, 2, 3 }),
+					(null, 1, false, new []{ 4, 5, 6 }),
+				},
+				// Edo Task Item Identification Codes
+				new[]
+				{
+					1, 2, 3, 4, 5, 6, 7, 8, 9
+				});
+
+			var mainFiscalDocument = new EdoFiscalDocument { Index = 0 };
+			receiptEdoTask.FiscalDocuments.Add(mainFiscalDocument);
+
+			// Act
+
+			await _forOwnNeedsReceiptEdoTaskHandler.UpdateMarkedFiscalDocuments(receiptEdoTask, mainFiscalDocument, default);
+
+			// Assert
+
+			var inventPositions = receiptEdoTask.FiscalDocuments.SelectMany(x => x.InventPositions).ToList();
+
+			// ровно один групповой код применён — одной объединённой строкой на 3 единицы
+			var groupPositions = inventPositions.Where(x => x.GroupCode != null).ToList();
+			Assert.Single(groupPositions);
+			Assert.Equal(3m, groupPositions[0].Quantity);
+
+			// оставшиеся 3 единицы (из отклонённого группового кода) стали отдельными строками чека
+			var individualPositions = inventPositions.Where(x => x.GroupCode == null).ToList();
+			Assert.Equal(3, individualPositions.Count);
+			Assert.All(individualPositions, x => Assert.Equal(1m, x.Quantity));
+			Assert.All(individualPositions, x => Assert.NotNull(x.EdoTaskItem));
+
+			// итоговое количество и стоимость соответствуют исходному заказу
+			Assert.Equal(
+				receiptEdoTask.FormalEdoRequest.Order.OrderItems.Where(x => x.Nomenclature.IsAccountableInTrueMark).Sum(x => x.Count),
+				inventPositions.Sum(x => x.Quantity));
+
+			Assert.Equal(
+				receiptEdoTask.FormalEdoRequest.Order.OrderItems
+					.Where(x => x.Nomenclature.IsAccountableInTrueMark && x.Count > 0)
+					.Sum(x => x.Sum),
+				inventPositions.Sum(x => x.Price * x.Quantity - x.DiscountSum));
+
+			// входящие в отклонённый групповой код 3 штучных кода возвращены в пул
+			await _trueMarkCodesPool.Received(3).PutCodeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
 		}
 
 		private ReceiptEdoTask CreateTestReceiptEdoTaskForTest(
@@ -446,7 +683,10 @@ namespace Receipt.Dispatcher.Tests
 			var order = new OrderEntity
 			{
 				Id = 1,
-				Contract = new CounterpartyContractEntity()
+				Contract = new CounterpartyContractEntity
+				{
+					Organization = new OrganizationEntity { INN = "0000000000" }
+				}
 			};
 
 			foreach(var orderItem in orderItems)
@@ -481,6 +721,13 @@ namespace Receipt.Dispatcher.Tests
 				nomenclature.GroupGtins.Add(groupGtin);
 			}
 
+			nomenclature.VatRateVersions.Add(new VatRateVersion
+			{
+				StartDate = new DateTime(2000, 1, 1),
+				EndDate = null,
+				VatRate = new VatRate { VatRateValue = 0m }
+			});
+
 			return nomenclature;
 		}
 
@@ -510,16 +757,27 @@ namespace Receipt.Dispatcher.Tests
 			var httpClientFactory = Substitute.For<IHttpClientFactory>();
 			var edoProblemRegistrar = CreateEdoProblemRegistrarFixture(unitOfWork, unitOfWorkFactory);
 			var edoTaskValidator = CreateEdoTaskValidatorFixture(unitOfWorkFactory, edoProblemRegistrar);
-			var edoTaskTrueMarkCodeCheckerFactory = Substitute.For<EdoTaskItemTrueMarkStatusProviderFactory>();
+			var edoTaskTrueMarkCodeCheckerFactory = Substitute.For<EdoTaskItemTrueMarkStatusProviderFactory>(Substitute.For<ITrueMarkApiClient>());
 			var transferRequestCreator = CreateTransferRequestCreatorFixture(edoRepository);
 			var edoReceiptSettings = Substitute.For<IEdoReceiptSettings>();
-			var localCodesValidator = CreateTrueMarkTaskCodesValidatorFixture(edoRepository, Substitute.For<TrueMarkApiClient>());
+			edoReceiptSettings.MaxCodesInReceiptCount.Returns(1000);
+			var localCodesValidator = CreateTrueMarkTaskCodesValidatorFixture(edoRepository, Substitute.For<ITrueMarkApiClient>());
 			var tag1260Checker = CreateTag1260CheckerFixture(httpClientFactory);
 			var trueMarkCodeRepository = Substitute.For<ITrueMarkCodeRepository>();
+			trueMarkCodeRepository
+				.GetGroupCode(Arg.Any<int>(), Arg.Any<CancellationToken>())
+				.Returns(callInfo => Task.FromResult(
+					_waterGroupCodeRepository.Data.FirstOrDefault(x => x.Id == (int)callInfo[0])));
 			var saveCodesService = Substitute.For<ISaveCodesService>();
 			var bus = Substitute.For<IBus>();
-			var edoCancellationService = Substitute.For<EdoCancellationService>();
+			var edoCancellationService = new EdoCancellationService(
+				Substitute.For<ILogger<EdoCancellationService>>(),
+				unitOfWork,
+				Substitute.For<IEdoCancellationValidator>(),
+				edoProblemRegistrar,
+				Substitute.For<IPublishEndpoint>());
 			var trueMarkWaterCodeService = Substitute.For<ITrueMarkWaterCodeService>();
+			_trueMarkCodesPool = Substitute.For<ReceiptTrueMarkCodesPool>(unitOfWork);
 
 			return new ForOwnNeedsReceiptEdoTaskHandler(
 				logger,
@@ -531,7 +789,7 @@ namespace Receipt.Dispatcher.Tests
 				edoRepository,
 				edoReceiptSettings,
 				localCodesValidator,
-				Substitute.For<ITrueMarkCodesPool>() as ReceiptTrueMarkCodesPool, 
+				_trueMarkCodesPool,
 				Substitute.For<ITrueMarkCodesPoolCodeProvider>(),
 				tag1260Checker,
 				trueMarkCodeRepository,


### PR DESCRIPTION
Замена группового кода штучными из пула при невозможности получить стоимость за единицу товара без остатка
Вложенные в отклоненный групповой код штучные отправляются в пул