### PR TITLE
5247 добавление обработчиков для Fault события

### DIFF
--- a/Source/Applications/Backend/Workers/Docker/Edo/Edo.Transfer.Dispatcher.ErrorDebugWorker/Program.cs
+++ b/Source/Applications/Backend/Workers/Docker/Edo/Edo.Transfer.Dispatcher.ErrorDebugWorker/Program.cs
@@ -22,6 +22,11 @@ using ModulKassa;
 using NLog.Extensions.Logging;
 using QS.Project.Core;
 using System;
+using Edo.Documents.Consumers.Definitions;
+using Edo.Documents.Consumers.Fault;
+using Edo.Receipt.Dispatcher.Consumers;
+using Edo.Receipt.Dispatcher.Consumers.Definitions;
+using Edo.Receipt.Dispatcher.Consumers.Fault;
 using TrueMark.Codes.Pool;
 using Vodovoz.Core.Data.NHibernate;
 using Vodovoz.Core.Domain.Repositories;
@@ -90,7 +95,6 @@ namespace Edo.Transfer.Dispatcher.ErrorDebugWorker
 						.AddEdoTransferSenderServices()
 						;
 
-
 					services.TryAddScoped<ITrueMarkWaterCodeService, TrueMarkWaterCodeService>();
 
 					services.AddEdo();
@@ -101,7 +105,14 @@ namespace Edo.Transfer.Dispatcher.ErrorDebugWorker
 						configureBus: cfg =>
 						{
 							// Выбор какой консюмер дебажить:
-
+							
+							//faults
+							//cfg.AddConsumer<FaultTransferCompleteConsumer>();
+							//cfg.AddConsumer<FaultDocumentTaskCreatedConsumer, FaultDocumentTaskCreatedConsumerDefinition>();
+							//cfg.AddConsumer<FaultTransferCompleteConsumer>();
+							
+							//cfg.AddConsumer<FaultReceiptTaskCreatedConsumer>();
+							
 							//request
 							//cfg.AddConsumer<EdoRequestCreatedErrorConsumer, EdoRequestCreatedErrorConsumerDefinition>();
 
@@ -111,12 +122,20 @@ namespace Edo.Transfer.Dispatcher.ErrorDebugWorker
 							cfg.AddConsumer<OrderDocumentAcceptedErrorConsumer, OrderDocumentAcceptedErrorConsumerDefinition>();
 
 							//receipt
+							//cfg.AddConsumer<ReceiptTaskCreatedConsumer, ReceiptTaskCreatedConsumerDefinition>();
 							//cfg.AddConsumer<ReceiptTaskCreatedErrorConsumer, ReceiptTaskCreatedErrorConsumerDefinition>();
 							//cfg.AddConsumer<ReceiptReadyToSendErrorConsumer, ReceiptReadyToSendErrorConsumerDefinition>();
 							//cfg.AddConsumer<ReceiptTransferCompleteErrorConsumer, ReceiptTransferCompleteErrorConsumerDefinition>();
+							
+							//cfg.AddConsumer<
+							//	Edo.Receipt.Dispatcher.Consumers.TransferCompleteConsumer,
+							//	Edo.Receipt.Dispatcher.Consumers.Definitions.TransferCompleteConsumerDefinition>();
 
 							//transfer
 							//cfg.AddConsumer<TransferDocumentAcceptedErrorConsumer, TransferDocumentAcceptedErrorConsumerDefinition>();
+							//cfg.AddConsumer<
+							//	Edo.Documents.Consumers.TransferCompleteConsumer,
+							//	Edo.Documents.Consumers.Definitions.TransferCompleteConsumerDefinition>();
 
 							//docflow
 							//cfg.AddConsumer<DocflowUpdatedErrorConsumer, DocflowUpdatedErrorConsumerDefinition>();

--- a/Source/Libraries/Core/Backend/Edo/Edo.CodesSaver/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.CodesSaver/DependencyInjection.cs
@@ -28,7 +28,7 @@ namespace Edo.CodesSaver
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/OrderDocumentSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/OrderDocumentSendConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Docflow.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<OrderDocumentSendEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/OrderDocumentSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/OrderDocumentSendConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Docflow.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<OrderDocumentSendEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/TransferDocumentSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/TransferDocumentSendConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Docflow.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<TransferDocumentSendEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/TransferDocumentSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Definitions/TransferDocumentSendConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Docflow.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<TransferDocumentSendEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultOrderDocumentSendConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultOrderDocumentSendConsumer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Docflow.Handlers;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Docflow.Consumers.Fault
+{
+	public class FaultOrderDocumentSendConsumer : IConsumer<Fault<OrderDocumentSendEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultOrderDocumentSendExceptionHandler _faultHandler;
+
+		public FaultOrderDocumentSendConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultOrderDocumentSendExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<OrderDocumentSendEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий отправки УПД по ЭДО"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultOrderDocumentSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultOrderDocumentSendConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Docflow.Consumers.Fault
+{
+	public class FaultOrderDocumentSendConsumerDefinition : ConsumerDefinition<FaultOrderDocumentSendConsumer>
+	{
+		public FaultOrderDocumentSendConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.order-document-send.consumer.docflow_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultOrderDocumentSendConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<OrderDocumentSendEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultTransferDocumentSendConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultTransferDocumentSendConsumer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Docflow.Handlers;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Docflow.Consumers.Fault
+{
+	public class FaultTransferDocumentSendConsumer : IConsumer<Fault<TransferDocumentSendEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultTransferDocumentSendExceptionHandler _faultHandler;
+
+		public FaultTransferDocumentSendConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultTransferDocumentSendExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<TransferDocumentSendEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий отправки трансфера"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultTransferDocumentSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Consumers/Fault/FaultTransferDocumentSendConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Docflow.Consumers.Fault
+{
+	public class FaultTransferDocumentSendConsumerDefinition : ConsumerDefinition<FaultTransferDocumentSendConsumer>
+	{
+		public FaultTransferDocumentSendConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.transfer-document-send.consumer.docflow_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultTransferDocumentSendConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<TransferDocumentSendEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/DependencyInjection.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using QS.DomainModel.UoW;
 using System.Reflection;
+using Edo.Transport.Factories;
 using Vodovoz.Core.Domain.Controllers;
 
 namespace Edo.Docflow
@@ -24,6 +25,7 @@ namespace Edo.Docflow
 			services.TryAddScoped<ICounterpartyEdoAccountEntityController, CounterpartyEdoAccountEntityController>();
 			services.TryAddScoped<IInformalOrderDocumentHandlerFactory, InformalOrderDocumentHandlerFactory>();
 			services.TryAddScoped<IInformalOrderDocumentHandler, EquipmentTransferDocumentHandler>();
+			services.AddFaultServices();
 			
 			return services;
 		}
@@ -37,6 +39,15 @@ namespace Edo.Docflow
 				cfg.AddConsumers(Assembly.GetExecutingAssembly());
 			});
 
+			return services;
+		}
+
+		public static IServiceCollection AddFaultServices(this IServiceCollection services)
+		{
+			services.TryAddScoped<FaultOrderDocumentSendExceptionHandler>();
+			services.TryAddScoped<FaultTransferDocumentSendExceptionHandler>();
+			services.TryAddScoped<IMassTransitExceptionInfoFactory, MassTransitExceptionInfoFactory>();
+			
 			return services;
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/DependencyInjection.cs
@@ -36,7 +36,7 @@ namespace Edo.Docflow
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Edo.Docflow.csproj
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Edo.Docflow.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\..\Business\Vodovoz.Core.Data\Vodovoz.Core.Data.csproj" />
+	  <ProjectReference Include="..\Edo.Problems\Edo.Problems.csproj" />
 	  <ProjectReference Include="..\Edo.Transport\Edo.Transport.csproj" />
 	  <ProjectReference Include="..\..\..\..\External\QSProjects\QS.Project.Core\QS.Project.Core.csproj" />
 	  <ProjectReference Include="..\..\..\Business\Vodovoz.Core.Domain\Vodovoz.Core.Domain.csproj" />

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Handlers/FaultOrderDocumentSendExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Handlers/FaultOrderDocumentSendExceptionHandler.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Core.Infrastructure;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Docflow.Handlers
+{
+	public class FaultOrderDocumentSendExceptionHandler
+	{
+		private readonly ILogger<FaultOrderDocumentSendExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly IGenericRepository<OrderEdoDocument> _edoDocumentRepository;
+		private readonly IGenericRepository<DocumentEdoTask> _edoTaskRepository;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultOrderDocumentSendExceptionHandler(
+			ILogger<FaultOrderDocumentSendExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			IGenericRepository<OrderEdoDocument> edoDocumentRepository,
+			IGenericRepository<DocumentEdoTask> edoTaskRepository,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_edoDocumentRepository = edoDocumentRepository ?? throw new ArgumentNullException(nameof(edoDocumentRepository));
+			_edoTaskRepository = edoTaskRepository ?? throw new ArgumentNullException(nameof(edoTaskRepository));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<OrderDocumentSendEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var documentId = fault.Message.OrderDocumentId;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие об отправке клиентского документа {DocumentId} без ошибок, пропускаем",
+					documentId);
+
+				return;
+			}
+
+			DocumentEdoTask documentTask = null;
+
+			try
+			{
+				var document = _edoDocumentRepository.GetFirstOrDefault(uow, x => x.Id == documentId);
+				if(document is null)
+				{
+					_logger.LogWarning("Документ {DocumentId} не найден", documentId);
+					return;
+				}
+
+				if(document.Status.IsIn(
+						EdoDocumentStatus.InProgress,
+						EdoDocumentStatus.CompletedWithDivergences,
+						EdoDocumentStatus.Succeed
+					))
+				{
+					_logger.LogError("Документ {DocumentId} уже в работе, повторно отправить нельзя", documentId);
+					return;
+				}
+
+				documentTask = _edoTaskRepository.GetFirstOrDefault(uow, x => x.Id == document.DocumentTaskId);
+				if(documentTask is null)
+				{
+					_logger.LogWarning("Задача для документа {DocumentId} не найдена", documentId);
+					return;
+				}
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, documentTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события отправки клиентского документа {DocumentId}",
+					documentId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, documentTask, ex, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Handlers/FaultTransferDocumentSendExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Docflow/Handlers/FaultTransferDocumentSendExceptionHandler.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Core.Infrastructure;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Docflow.Handlers
+{
+	public class FaultTransferDocumentSendExceptionHandler
+	{
+		private readonly ILogger<FaultTransferDocumentSendExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly IGenericRepository<TransferEdoDocument> _edoDocumentRepository;
+		private readonly IGenericRepository<TransferEdoTask> _transferTaskRepository;
+		private readonly IGenericRepository<DocumentEdoTask> _edoTaskRepository;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultTransferDocumentSendExceptionHandler(
+			ILogger<FaultTransferDocumentSendExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			IGenericRepository<TransferEdoDocument> edoDocumentRepository,
+			IGenericRepository<TransferEdoTask> transferTaskRepository,
+			IGenericRepository<DocumentEdoTask> edoTaskRepository,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_edoDocumentRepository = edoDocumentRepository ?? throw new ArgumentNullException(nameof(edoDocumentRepository));
+			_transferTaskRepository = transferTaskRepository ?? throw new ArgumentNullException(nameof(transferTaskRepository));
+			_edoTaskRepository = edoTaskRepository ?? throw new ArgumentNullException(nameof(edoTaskRepository));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<TransferDocumentSendEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var documentId = fault.Message.TransferDocumentId;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие об отправке трансфера {DocumentId} без ошибок, пропускаем",
+					documentId);
+
+				return;
+			}
+
+			IEnumerable<int> orderTaskIds = null;
+
+			try
+			{
+				var document = _edoDocumentRepository.GetFirstOrDefault(uow, x => x.Id == documentId);
+				if(document is null)
+				{
+					_logger.LogWarning("Трансфер документ {documentId} не найден", documentId);
+					return;
+				}
+
+				if(document.Status.IsIn(
+						EdoDocumentStatus.InProgress,
+						EdoDocumentStatus.CompletedWithDivergences,
+						EdoDocumentStatus.Succeed
+					))
+				{
+					_logger.LogError("Документ {DocumentId} уже в работе, повторно отправить нельзя", documentId);
+					return;
+				}
+
+				var transferTask = _transferTaskRepository.GetFirstOrDefault(uow, x => x.Id == document.TransferTaskId);
+				if(transferTask is null)
+				{
+					_logger.LogWarning("Трансфер задача для документа {DocumentId} не найдена", documentId);
+					return;
+				}
+
+				orderTaskIds = transferTask.TransferEdoRequests
+					.Select(x => x.Iteration.OrderEdoTask.Id)
+					.Distinct();
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, orderTaskIds, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события об отправке трансфера {DocumentId}",
+					documentId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, orderTaskIds, new []{ _exceptionInfoFactory.Create(ex) }, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/DocumentTaskCreatedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/DocumentTaskCreatedConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Documents.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<DocumentTaskCreatedEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentAcceptedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentAcceptedConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Documents.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<OrderDocumentAcceptedEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentAcceptedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentAcceptedConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Documents.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<OrderDocumentAcceptedEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentSentConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentSentConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Documents.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<OrderDocumentSentEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentSentConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/OrderDocumentSentConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Documents.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<OrderDocumentSentEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
@@ -25,6 +25,7 @@ namespace Edo.Documents.Consumers.Definitions
 				{
 					x.RoutingKey = TransferInitiator.Document.ToString();
 				});
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
@@ -25,7 +25,7 @@ namespace Edo.Documents.Consumers.Definitions
 				{
 					x.RoutingKey = TransferInitiator.Document.ToString();
 				});
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultDocumentTaskCreatedConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultDocumentTaskCreatedConsumer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultDocumentTaskCreatedConsumer : IConsumer<Fault<DocumentTaskCreatedEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultDocumentTaskCreatedExceptionHandler _faultHandler;
+
+		public FaultDocumentTaskCreatedConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultDocumentTaskCreatedExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<DocumentTaskCreatedEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий создания заявки по документу ЭДО"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultDocumentTaskCreatedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultDocumentTaskCreatedConsumerDefinition.cs
@@ -1,0 +1,27 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultDocumentTaskCreatedConsumerDefinition : ConsumerDefinition<FaultDocumentTaskCreatedConsumer>
+	{
+		public FaultDocumentTaskCreatedConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.document-task-created.consumer.documents_error");
+		}
+
+		protected override void ConfigureConsumer(
+			IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultDocumentTaskCreatedConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<DocumentTaskCreatedEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentAcceptedConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentAcceptedConsumer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultOrderDocumentAcceptedConsumer : IConsumer<Fault<OrderDocumentAcceptedEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultOrderDocumentAcceptedExceptionHandler _faultHandler;
+
+		public FaultOrderDocumentAcceptedConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultOrderDocumentAcceptedExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<OrderDocumentAcceptedEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий подтверждения клиентского документа ЭДО"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentAcceptedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentAcceptedConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultOrderDocumentAcceptedConsumerDefinition : ConsumerDefinition<FaultOrderDocumentAcceptedConsumer>
+	{
+		public FaultOrderDocumentAcceptedConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.customer-document-accepted.consumer.documents_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultOrderDocumentAcceptedConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<OrderDocumentAcceptedEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentSentConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentSentConsumer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultOrderDocumentSentConsumer : IConsumer<Fault<OrderDocumentSentEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultOrderDocumentSentExceptionHandler _faultHandler;
+
+		public FaultOrderDocumentSentConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultOrderDocumentSentExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+
+		public async Task Consume(ConsumeContext<Fault<OrderDocumentSentEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий об отправке документа"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}
+

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentSentConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultOrderDocumentSentConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultOrderDocumentSentConsumerDefinition : ConsumerDefinition<FaultOrderDocumentSentConsumer>
+	{
+		public FaultOrderDocumentSentConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.order-document-sent.consumer.documents_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultOrderDocumentSentConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<OrderDocumentSentEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultTransferCompleteConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultTransferCompleteConsumer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultTransferCompleteConsumer : IConsumer<Fault<TransferCompleteEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultTransferCompleteExceptionHandler _faultHandler;
+
+		public FaultTransferCompleteConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultTransferCompleteExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<TransferCompleteEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий завершения трансфера"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultTransferCompleteConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/Consumers/Fault/FaultTransferCompleteConsumerDefinition.cs
@@ -1,0 +1,31 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+using Vodovoz.Core.Domain.Edo;
+
+namespace Edo.Documents.Consumers.Fault
+{
+	public class FaultTransferCompleteConsumerDefinition : ConsumerDefinition<FaultTransferCompleteConsumer>
+	{
+		public FaultTransferCompleteConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.transfer-complete.consumer.documents_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultTransferCompleteConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+
+				rmq.Bind<TransferCompleteEvent>(x =>
+				{
+					x.RoutingKey = TransferInitiator.Document.ToString();
+				});
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using QS.DomainModel.UoW;
 using System.Reflection;
+using Edo.Documents.Consumers.Fault;
 using Edo.Transport.Factories;
 using TrueMark.Codes.Pool;
 
@@ -41,7 +42,8 @@ namespace Edo.Documents
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
+				cfg.AddConsumer<FaultDocumentTaskCreatedConsumer>();
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/DependencyInjection.cs
@@ -1,6 +1,5 @@
 ﻿using Edo.Admin;
 using Edo.Common;
-using Edo.Common.Services;
 using Edo.Documents.Services;
 using Edo.Problems;
 using Edo.Transport;
@@ -9,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using QS.DomainModel.UoW;
 using System.Reflection;
+using Edo.Transport.Factories;
 using TrueMark.Codes.Pool;
 
 namespace Edo.Documents
@@ -26,10 +26,11 @@ namespace Edo.Documents
 			services.TryAddScoped<ForResaleDocumentEdoTaskHandler>();
 			services.TryAddScoped<WithdrawalEdoRequestHandler>();
 
-			services.AddEdo();
-			services.AddCodesPool();
-			services.AddEdoProblemRegistration();
-			services.AddEdoAdminServices();
+			services.AddEdo()
+				.AddCodesPool()
+				.AddEdoProblemRegistration()
+				.AddEdoAdminServices()
+				.AddFaultServices();
 			
 			return services;
 		}
@@ -42,6 +43,20 @@ namespace Edo.Documents
 			{
 				cfg.AddConsumers(Assembly.GetExecutingAssembly());
 			});
+
+			return services;
+		}
+		
+		public static IServiceCollection AddFaultServices(this IServiceCollection services)
+		{
+			services
+				.AddScoped<FaultTransferCompleteExceptionHandler>()
+				.AddScoped<FaultDocumentTaskCreatedExceptionHandler>()
+				.AddScoped<FaultOrderDocumentSentExceptionHandler>()
+				.AddScoped<FaultOrderDocumentAcceptedExceptionHandler>()
+				;
+			
+			services.TryAddScoped<IMassTransitExceptionInfoFactory, MassTransitExceptionInfoFactory>();
 
 			return services;
 		}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultDocumentTaskCreatedExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultDocumentTaskCreatedExceptionHandler.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Documents
+{
+	public class FaultDocumentTaskCreatedExceptionHandler
+	{
+		private readonly ILogger<FaultDocumentTaskCreatedExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly IGenericRepository<DocumentEdoTask> _edoTaskRepository;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultDocumentTaskCreatedExceptionHandler(
+			ILogger<FaultDocumentTaskCreatedExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			IGenericRepository<DocumentEdoTask> edoTaskRepository,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_edoTaskRepository = edoTaskRepository ?? throw new ArgumentNullException(nameof(edoTaskRepository));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+		
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<DocumentTaskCreatedEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var edoTaskId = fault.Message.Id;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие о созданной задаче {EdoTaskId} по ЭДО документу без ошибок, пропускаем",
+					edoTaskId);
+
+				return;
+			}
+			
+			DocumentEdoTask edoTask = null;
+
+			try
+			{
+				edoTask = _edoTaskRepository.GetFirstOrDefault(uow, x => x.Id == edoTaskId);
+
+				if(edoTask is null)
+				{
+					_logger.LogInformation("Задача Id {EdoTaskId} не найдена", edoTaskId);
+					return;
+				}
+
+				if(edoTask.Stage != DocumentEdoTaskStage.New)
+				{
+					_logger.LogInformation("Задача Id {EdoTaskId} уже в работе", edoTaskId);
+					return;
+				}
+
+				if(edoTask.FormalEdoRequest is null)
+				{
+					_logger.LogInformation("Задача Id {EdoTaskId} не имеет связи с ЭДО заявкой", edoTaskId);
+					return;
+				}
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события о созданной задаче {EdoTaskId}",
+					edoTaskId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, ex, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultOrderDocumentAcceptedExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultOrderDocumentAcceptedExceptionHandler.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Documents
+{
+	public class FaultOrderDocumentAcceptedExceptionHandler
+	{
+		private readonly ILogger<FaultOrderDocumentAcceptedExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly IGenericRepository<OrderEdoDocument> _edoDocumentRepository;
+		private readonly IGenericRepository<DocumentEdoTask> _edoTaskRepository;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultOrderDocumentAcceptedExceptionHandler(
+			ILogger<FaultOrderDocumentAcceptedExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			IGenericRepository<OrderEdoDocument> edoDocumentRepository,
+			IGenericRepository<DocumentEdoTask> edoTaskRepository,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_edoDocumentRepository = edoDocumentRepository ?? throw new ArgumentNullException(nameof(edoDocumentRepository));
+			_edoTaskRepository = edoTaskRepository ?? throw new ArgumentNullException(nameof(edoTaskRepository));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+		
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<OrderDocumentAcceptedEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var documentId = fault.Message.DocumentId;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие о подтверждении клиентского документа {DocumentId} без ошибок, пропускаем",
+					documentId);
+
+				return;
+			}
+			
+			DocumentEdoTask edoTask = null;
+
+			try
+			{
+				var document = _edoDocumentRepository.GetFirstOrDefault(uow, x => x.Id == documentId);
+				if(document is null)
+				{
+					_logger.LogWarning("Документ №{DocumentId} не найден", documentId);
+					return;
+				}
+
+				edoTask = _edoTaskRepository.GetFirstOrDefault(uow, x => x.Id == document.DocumentTaskId);
+				
+				if(edoTask is null)
+				{
+					_logger.LogWarning("Задача ЭДО №{EdoTaskId} не найдена", document.DocumentTaskId);
+					return;
+				}
+
+				if(edoTask.FormalEdoRequest is null)
+				{
+					_logger.LogInformation("Задача Id {EdoTaskId} не имеет связи с ЭДО заявкой", document.DocumentTaskId);
+					return;
+				}
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события о подтверждении клиентского документа {DocumentId}",
+					documentId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, ex, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultOrderDocumentSentExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultOrderDocumentSentExceptionHandler.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+
+namespace Edo.Documents
+{
+	public class FaultOrderDocumentSentExceptionHandler
+	{
+		private readonly ILogger<FaultOrderDocumentSentExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultOrderDocumentSentExceptionHandler(
+			ILogger<FaultOrderDocumentSentExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+		
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<OrderDocumentSentEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var documentId = fault.Message.Id;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие об отправке документа {DocumentId} без ошибок, пропускаем",
+					documentId);
+
+				return;
+			}
+			
+			DocumentEdoTask edoTask = null;
+
+			try
+			{
+				var document = await uow.Session.GetAsync<OrderEdoDocument>(documentId, cancellationToken);
+				if(document is null)
+				{
+					_logger.LogWarning("Документ №{DocumentId} не найден", documentId);
+					return;
+				}
+
+				edoTask = await uow.Session.GetAsync<DocumentEdoTask>(document.DocumentTaskId, cancellationToken);
+				
+				if(edoTask is null)
+				{
+					_logger.LogWarning("Задача ЭДО №{EdoTaskId} не найдена", document.DocumentTaskId);
+					return;
+				}
+
+				if(edoTask.FormalEdoRequest is null)
+				{
+					_logger.LogInformation("Задача Id {EdoTaskId} не имеет связи с ЭДО заявкой", document.DocumentTaskId);
+					return;
+				}
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события об отправке документа {DocumentId}",
+					documentId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, ex, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultTransferCompleteExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Documents/FaultTransferCompleteExceptionHandler.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Documents
+{
+	public class FaultTransferCompleteExceptionHandler
+	{
+		private readonly ILogger<FaultTransferCompleteExceptionHandler> _logger;
+		private readonly IGenericRepository<TransferEdoRequestIteration> _transferIterationRepository;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultTransferCompleteExceptionHandler(
+			ILogger<FaultTransferCompleteExceptionHandler> logger,
+			IGenericRepository<TransferEdoRequestIteration> transferIterationRepository,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_transferIterationRepository = transferIterationRepository ?? throw new ArgumentNullException(nameof(transferIterationRepository));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<TransferCompleteEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var transferIterationId = fault.Message.TransferIterationId;
+			
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие завершения трансфера с итерацией {TransferIterationId} без ошибок, пропускаем",
+					transferIterationId);
+
+				return;
+			}
+
+			EdoTask edoTask = null;
+			
+			try
+			{
+				var transferIterations = await _transferIterationRepository
+					.GetAsync(uow, x => x.Id == transferIterationId, cancellationToken: cancellationToken);
+
+				var transferIteration = transferIterations.Value.FirstOrDefault();
+
+				//TODO вынести условия в отдельные или совместный обработчик, т.к. они есть также в DocumentEdoTaskHandler
+				if(transferIteration is null)
+				{
+					_logger.LogInformation("Итерация трансфера Id {TransferIterationId} не найдена", transferIterationId);
+					return;
+				}
+
+				if(!TryGetTaskAndCheck(fault, transferIteration, ref edoTask))
+				{
+					return;
+				}
+
+				if(edoTask is null)
+				{
+					_logger.LogInformation("Невозможно выполнить завершение трансфера, " +
+						"так как задача Id {EdoTaskId} не найдена", transferIteration.OrderEdoTask.Id);
+
+					return;
+				}
+				
+				if(edoTask.Status is EdoTaskStatus.Completed)
+				{
+					_logger.LogInformation("Невозможно выполнить завершение трансфера, " +
+						"так как задача Id {EdoTaskId} уже завершена", edoTask.Id);
+					
+					return;
+				}
+
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события завершения трансфера с итерацией {TransferIterationId}",
+					transferIterationId);
+				
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, ex, cancellationToken);
+			}
+		}
+
+		private bool TryGetTaskAndCheck(
+			Fault<TransferCompleteEvent> fault,
+			TransferEdoRequestIteration transferIteration,
+			ref EdoTask edoTask)
+		{
+			switch(fault.Message.TransferInitiator)
+			{
+				case TransferInitiator.Document:
+					var documentEdoTask = transferIteration.OrderEdoTask.As<DocumentEdoTask>();
+					if(!CheckDocumentTask(documentEdoTask))
+					{
+						return false;
+					};
+					edoTask = documentEdoTask;
+					break;
+				case TransferInitiator.Receipt:
+					var receiptEdoTask = transferIteration.OrderEdoTask.As<ReceiptEdoTask>();
+					if(!CheckReceiptTask(receiptEdoTask))
+					{
+						return false;
+					};
+					edoTask = receiptEdoTask;
+					break;
+				case TransferInitiator.Tender:
+					var tenderEdoTask = transferIteration.OrderEdoTask.As<TenderEdoTask>();
+					if(!CheckTenderTask(tenderEdoTask))
+					{
+						return false;
+					};
+					edoTask = tenderEdoTask;
+					break;
+			}
+
+			return true;
+		}
+
+		private bool CheckTenderTask(TenderEdoTask tenderEdoTask)
+		{
+			if(tenderEdoTask is null)
+			{
+				_logger.LogInformation("Невозможно выполнить завершение трансфера, т.к. не удалось определить задачу");
+				return false;
+			}
+			
+			if(tenderEdoTask.Stage != TenderEdoTaskStage.Transfering)
+			{
+				_logger.LogInformation("Невозможно выполнить завершение трансфера, " +
+					"так как задача Id {TenderEdoTaskId} находится не на стадии трансфера, " +
+					"а на стадии {DocumentEdoTaskStage}",
+					tenderEdoTask.Id, tenderEdoTask.Stage);
+				
+				return false;
+			}
+
+			return true;
+		}
+
+		private bool CheckReceiptTask(ReceiptEdoTask receiptEdoTask)
+		{
+			if(receiptEdoTask is null)
+			{
+				_logger.LogInformation("Невозможно выполнить завершение трансфера, т.к. не удалось определить задачу");
+				return false;
+			}
+			
+			if(receiptEdoTask.ReceiptStatus != EdoReceiptStatus.Transfering)
+			{
+				_logger.LogInformation(
+					"Невозможно выполнить завершение трансфера, так как задача Id {ReceiptEdoTaskId} " +
+					"находится не на стадии трансфера, а на стадии {ReceiptEdoTaskReceiptStatus}",
+					receiptEdoTask.Id,
+					receiptEdoTask.ReceiptStatus);
+
+				return false;
+			}
+			
+			return true;
+		}
+
+		private bool CheckDocumentTask(DocumentEdoTask documentEdoTask)
+		{
+			if(documentEdoTask is null)
+			{
+				_logger.LogInformation("Невозможно выполнить завершение трансфера, т.к. не удалось определить задачу");
+				return false;
+			}
+			
+			if(documentEdoTask.Stage != DocumentEdoTaskStage.Transfering)
+			{
+				_logger.LogInformation(
+					"Невозможно выполнить завершение трансфера, так как задача Id {EdoTaskId} " +
+					"находится не на стадии трансфера, а на стадии {DocumentEdoTaskStage}",
+					documentEdoTask.Id,
+					documentEdoTask.Stage);
+
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.InformalOrderDocuments/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.InformalOrderDocuments/DependencyInjection.cs
@@ -44,7 +44,7 @@ namespace Edo.InformalOrderDocuments
 				},
 				configureBus: cfg =>
 				{
-					cfg.AddConsumers(Assembly.GetExecutingAssembly());
+					cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 				}
 			);
 

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/DependencyInjection.cs
@@ -29,6 +29,7 @@ namespace Edo.Problems
 			services.TryAddScoped<EdoTaskValidatorsProvider>();
 			services.TryAddScoped<EdoTaskValidator>();
 			services.TryAddScoped<EdoProblemRegistrar>();
+			services.TryAddScoped<FaultEdoProblemRegistrar>();
 			services.TryAddScoped<ICounterpartyEdoAccountEntityController, CounterpartyEdoAccountEntityController>();
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/Edo.Problems.csproj
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/Edo.Problems.csproj
@@ -9,6 +9,7 @@
 		<ProjectReference Include="..\..\TrueMark\TrueMark.Codes.Pool\TrueMark.Codes.Pool.csproj" />
 		<ProjectReference Include="..\..\TrueMark\TrueMark.Contracts\TrueMark.Contracts.csproj" />
 		<ProjectReference Include="..\Edo.Common\Edo.Common.csproj" />
+		<ProjectReference Include="..\Edo.Transport\Edo.Transport.csproj" />
 	</ItemGroup>
 	
 </Project>

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/EdoProblemRegistrar.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/EdoProblemRegistrar.cs
@@ -8,28 +8,25 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Vodovoz.Core.Domain.Edo;
 
 namespace Edo.Problems
 {
-	public class EdoProblemRegistrar
+	public class EdoProblemRegistrar : EdoProblemRegistrarBase
 	{
 		private readonly IUnitOfWork _taskUow;
 		private readonly IUnitOfWorkFactory _uowFactory;
-		private readonly EdoTaskCustomSourcesPersister _customSourcesPersister;
-		private readonly EdoTaskExceptionSourcesPersister _exceptionSourcesPersister;
 
 		public EdoProblemRegistrar(
 			IUnitOfWork taskUow,
 			IUnitOfWorkFactory uowFactory,
 			EdoTaskCustomSourcesPersister customSourcesPersister,
 			EdoTaskExceptionSourcesPersister exceptionSourcesPersister
-			)
+			) : base(customSourcesPersister, exceptionSourcesPersister)
 		{
 			_taskUow = taskUow ?? throw new ArgumentNullException(nameof(taskUow));
 			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
-			_customSourcesPersister = customSourcesPersister ?? throw new ArgumentNullException(nameof(customSourcesPersister));
-			_exceptionSourcesPersister = exceptionSourcesPersister ?? throw new ArgumentNullException(nameof(exceptionSourcesPersister));
 		}
 
 		public async Task RegisterCustomProblem<TCustomSource>(
@@ -56,18 +53,12 @@ namespace Edo.Problems
 			using(var uow = _uowFactory.CreateWithoutRoot())
 			{
 				var task = uow.GetById<EdoTask>(edoTask.Id);
-				var source = _customSourcesPersister.GetCustomSource<TCustomSource>();
+				var source = CustomSourcesPersister.GetCustomSource<TCustomSource>();
 				var problem = task.Problems.FirstOrDefault(x => x.SourceName == source.Name)
-					?? new CustomEdoTaskProblem
-					{
-						SourceName = source.Name,
-						EdoTask = task,
-						CustomMessage = customMessage
-					};
+					?? CustomEdoTaskProblem.Create(source.Name, task, customMessage);
 
 				problem.CreationTime = DateTime.Now;
 				problem.State = TaskProblemState.Active;
-				
 
 				problem.TaskItems.Clear();
 				foreach(var taskItem in affectedTaskItems)
@@ -132,18 +123,12 @@ namespace Edo.Problems
 			where TCustomSource : EdoTaskProblemCustomSource
 		{
 			var task = _taskUow.GetById<EdoTask>(edoTask.Id);
-			var source = _customSourcesPersister.GetCustomSource<TCustomSource>();
+			var source = CustomSourcesPersister.GetCustomSource<TCustomSource>();
 			var problem = task.Problems.FirstOrDefault(x => x.SourceName == source.Name)
-				?? new CustomEdoTaskProblem
-				{
-					SourceName = source.Name,
-					EdoTask = task,
-					CustomMessage = customMessage
-				};
+				?? CustomEdoTaskProblem.Create(source.Name, task, customMessage);
 
 			problem.CreationTime = DateTime.Now;
 			problem.State = solved ? TaskProblemState.Solved : TaskProblemState.Active;
-
 
 			problem.TaskItems.Clear();
 			foreach(var taskItem in affectedTaskItems)
@@ -209,29 +194,14 @@ namespace Edo.Problems
 			using(var uow = _uowFactory.CreateWithoutRoot())
 			{
 				var task = uow.GetById<EdoTask>(edoTask.Id);
-				var sourceName = exception.GetType().Name;
-				var sources = _exceptionSourcesPersister.GetEdoProblemExceptionSources();
-				var source = sources.SingleOrDefault(x => x.Name == sourceName);
+				var source = GetExceptionSource(exception);
 				if(source == null)
 				{
 					_taskUow.Dispose();
 					return false;
 				}
 
-				var problem = task.Problems.FirstOrDefault(x => x.SourceName == sourceName);
-				if(problem == null)
-				{
-					problem = new ExceptionEdoTaskProblem
-					{
-						SourceName = sourceName,
-						EdoTask = task,
-						ExceptionMessage = exception.Message
-					};
-					await uow.SaveAsync(problem, cancellationToken: cancellationToken);
-				}
-
-				problem.CreationTime = DateTime.Now;
-				problem.State = TaskProblemState.Active;
+				var problem = await GetExceptionProblemAndActivate(uow, task, exception.Message, source, cancellationToken, true);
 
 				// Удаляем старые строки задачи, которые не относятся к обновленной проблеме
 				// и добавляем новые строки задачи, которые относятся к проблеме
@@ -264,10 +234,7 @@ namespace Edo.Problems
 					await uow.SaveAsync(customItem, cancellationToken: cancellationToken);
 				}
 
-				task.Status = source.Importance == EdoProblemImportance.Problem
-					? EdoTaskStatus.Problem
-					: EdoTaskStatus.Waiting;
-
+				task.UpdateStatusByEdoProblemImportance(source.Importance);
 
 				await uow.SaveAsync(problem, cancellationToken: cancellationToken);
 				await uow.SaveAsync(task, cancellationToken: cancellationToken);
@@ -385,14 +352,14 @@ namespace Edo.Problems
 		public void SolveCustomProblem<TCustomSource>(EdoTask edoTask)
 			where TCustomSource : EdoTaskProblemCustomSource
 		{
-			var source = _customSourcesPersister.GetCustomSource<TCustomSource>();
+			var source = CustomSourcesPersister.GetCustomSource<TCustomSource>();
 			SolveProblem(edoTask, source.Name);
 		}
 
 		public void SolveExceptionProblem<TExceptionSource>(EdoTask edoTask)
 			where TExceptionSource : EdoTaskProblemExceptionSource
 		{
-			var source = _exceptionSourcesPersister.GetExceptionSource<TExceptionSource>();
+			var source = ExceptionSourcesPersister.GetExceptionSource<TExceptionSource>();
 			SolveProblem(edoTask, source.Name);
 		}
 

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/EdoProblemRegistrarBase.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/EdoProblemRegistrarBase.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Problems.Custom;
+using Edo.Problems.Exception;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+
+namespace Edo.Problems
+{
+	public abstract class EdoProblemRegistrarBase
+	{
+		protected EdoProblemRegistrarBase(
+			EdoTaskCustomSourcesPersister customSourcesPersister,
+			EdoTaskExceptionSourcesPersister exceptionSourcesPersister
+			)
+		{
+			CustomSourcesPersister = customSourcesPersister ?? throw new ArgumentNullException(nameof(customSourcesPersister));
+			ExceptionSourcesPersister = exceptionSourcesPersister ?? throw new ArgumentNullException(nameof(exceptionSourcesPersister));
+		}
+		
+		protected EdoTaskCustomSourcesPersister CustomSourcesPersister { get; }
+		protected EdoTaskExceptionSourcesPersister ExceptionSourcesPersister { get; }
+		
+		protected virtual EdoTaskProblemExceptionSource GetExceptionSource(System.Exception exception)
+		{
+			var sourceName = exception.GetType().Name;
+			var sources = ExceptionSourcesPersister.GetEdoProblemExceptionSources();
+			return sources.SingleOrDefault(x => x.Name == sourceName);
+		}
+		
+		protected virtual async Task<EdoTaskProblem> GetExceptionProblemAndActivate(
+			IUnitOfWork uow,
+			EdoTask task,
+			string exceptionMessage,
+			EdoTaskProblemExceptionSource source,
+			CancellationToken cancellationToken,
+			bool needSave = false
+		)
+		{
+			var problem = task.Problems.FirstOrDefault(x => x.SourceName == source.Name);
+			
+			if(problem is null)
+			{
+				problem = ExceptionEdoTaskProblem.Create(source.Name, task, exceptionMessage);
+				await uow.SaveAsync(problem, cancellationToken: cancellationToken);
+			}
+
+			problem.CreationTime = DateTime.Now;
+			problem.State = TaskProblemState.Active;
+			return problem;
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/Exception/Sources/DependencyMissing.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/Exception/Sources/DependencyMissing.cs
@@ -1,0 +1,16 @@
+﻿using Autofac.Core;
+using Vodovoz.Core.Domain.Edo;
+
+namespace Edo.Problems.Exception.Sources
+{
+	/// <summary>
+	/// Ошибка при отсутствии необходимой зависимости
+	/// </summary>
+	public class DependencyMissing : EdoTaskProblemExceptionSource
+	{
+		public override string Name => typeof(DependencyResolutionException).ToString();
+		public override string Description => "Нарушена работа важного сервиса. Не хватает обязательной зависимости";
+		public override string Recommendation => "Обратитесь в РПО";
+		public override EdoProblemImportance Importance => EdoProblemImportance.Problem;
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/Exception/Sources/UnknownException.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/Exception/Sources/UnknownException.cs
@@ -1,0 +1,17 @@
+﻿using Vodovoz.Core.Domain.Edo;
+
+namespace Edo.Problems.Exception.Sources
+{
+	/// <summary>
+	/// Неизвестная ошибка
+	/// </summary>
+	public class UnknownException : EdoTaskProblemExceptionSource
+	{
+		public override string Name => "UnknownException";
+		public override string Description => "Произошла неизвестная ошибка";
+		public override string Recommendation => "Обратитесь в РПО";
+		public override EdoProblemImportance Importance => EdoProblemImportance.Problem;
+		
+		public static UnknownException Create() => new UnknownException();
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Problems/FaultEdoProblemRegistrar.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Problems/FaultEdoProblemRegistrar.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Problems.Custom;
+using Edo.Problems.Exception;
+using Edo.Problems.Exception.Sources;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Problems
+{
+	public class FaultEdoProblemRegistrar : EdoProblemRegistrarBase
+	{
+		private readonly ILogger<FaultEdoProblemRegistrar> _logger;
+		private readonly IGenericRepository<EdoTask> _edoTaskRepository;
+
+		public FaultEdoProblemRegistrar(
+			ILogger<FaultEdoProblemRegistrar> logger,
+			IGenericRepository<EdoTask> edoTaskRepository,
+			EdoTaskCustomSourcesPersister customSourcesPersister,
+			EdoTaskExceptionSourcesPersister exceptionSourcesPersister
+			) : base(customSourcesPersister, exceptionSourcesPersister)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_edoTaskRepository = edoTaskRepository ?? throw new ArgumentNullException(nameof(edoTaskRepository));
+		}
+		
+		public async Task<bool> TryRegisterExceptionProblem(
+			IUnitOfWork uow,
+			EdoTask edoTask,
+			System.Exception exception,
+			CancellationToken cancellationToken
+		)
+		{
+			if(edoTask is null)
+			{
+				return false;
+			}
+			
+			_logger.LogError(exception, "Регистрируем ошибку при обработке задачи {EdoTaskId}", edoTask.Id);
+			
+			var source = GetExceptionSource(exception) ?? UnknownException.Create();
+			var problem = await GetExceptionProblemAndActivate(uow, edoTask, exception.Message, source, cancellationToken);
+			edoTask.UpdateStatusByEdoProblemImportance(source.Importance);
+
+			await uow.SaveAsync(problem, cancellationToken: cancellationToken);
+			await uow.SaveAsync(edoTask, cancellationToken: cancellationToken);
+			await uow.CommitAsync(cancellationToken);
+
+			return true;
+		}
+		
+		public async Task<bool> TryRegisterExceptionProblem(
+			IUnitOfWork uow,
+			EdoTask edoTask,
+			IEnumerable<MassTransitExceptionInfo> exceptions,
+			CancellationToken cancellationToken
+		)
+		{
+			if(edoTask is null)
+			{
+				return false;
+			}
+
+			EdoTaskProblemExceptionSource source = null;
+			MassTransitExceptionInfo exceptionInfo = null;
+			var sources = ExceptionSourcesPersister.GetEdoProblemExceptionSources();
+			
+			foreach(var exception in exceptions)
+			{
+				var sourceWithException = TryGetExceptionSource(exception, sources);
+				
+				if(sourceWithException.Source is null)
+				{
+					continue;
+				}
+
+				source = sourceWithException.Source;
+				exceptionInfo = sourceWithException.ExceptionInfo;
+				break;
+			}
+			
+			if(source is null)
+			{
+				source = UnknownException.Create();
+				exceptionInfo = exceptions.FirstOrDefault();
+			}
+
+			_logger.LogError("Регистрируем ошибку при обработке задачи {EdoTaskId}\n{StackTrace}", edoTask.Id, exceptionInfo?.StackTrace);
+			
+			var problem = await GetExceptionProblemAndActivate(uow, edoTask, exceptionInfo?.Message, source, cancellationToken);;
+			edoTask.UpdateStatusByEdoProblemImportance(source.Importance);
+
+			await uow.SaveAsync(problem, cancellationToken: cancellationToken);
+			await uow.SaveAsync(edoTask, cancellationToken: cancellationToken);
+			await uow.CommitAsync(cancellationToken);
+
+			return true;
+		}
+		
+		public async Task<bool> TryRegisterExceptionProblem(
+			IUnitOfWork uow,
+			IEnumerable<int> edoTaskIds,
+			IEnumerable<MassTransitExceptionInfo> exceptions,
+			CancellationToken cancellationToken
+		)
+		{
+			if(edoTaskIds is null || !edoTaskIds.Any())
+			{
+				return false;
+			}
+
+			foreach(var edoTaskId in edoTaskIds)
+			{
+				var edoTask = _edoTaskRepository.GetFirstOrDefault(uow, x => x.Id == edoTaskId);
+				await TryRegisterExceptionProblem(uow, edoTask, exceptions, cancellationToken);
+			}
+
+			return true;
+		}
+
+		private (MassTransitExceptionInfo ExceptionInfo, EdoTaskProblemExceptionSource Source) TryGetExceptionSource(
+			MassTransitExceptionInfo exception,
+			IEnumerable<EdoTaskProblemExceptionSource> sources)
+		{
+			var currentException = exception;
+
+			while(currentException != null)
+			{
+				var sourceName = exception.ExceptionType;
+				var source = sources.SingleOrDefault(x => x.Name == sourceName);
+
+				if(source != null)
+				{
+					return (currentException, source);
+				}
+				
+				currentException = currentException.InnerException;
+			}
+			
+			return (null, null);
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/ReceiptTaskCreatedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/ReceiptTaskCreatedConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Receipt.Dispatcher.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<ReceiptTaskCreatedEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/ReceiptTaskCreatedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/ReceiptTaskCreatedConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Receipt.Dispatcher.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<ReceiptTaskCreatedEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
@@ -26,7 +26,7 @@ namespace Edo.Receipt.Dispatcher.Consumers.Definitions
 					x.RoutingKey = TransferInitiator.Receipt.ToString();
 				});
 				
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Definitions/TransferCompleteConsumerDefinition.cs
@@ -25,6 +25,8 @@ namespace Edo.Receipt.Dispatcher.Consumers.Definitions
 				{
 					x.RoutingKey = TransferInitiator.Receipt.ToString();
 				});
+				
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Fault/FaultReceiptTaskCreatedConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Fault/FaultReceiptTaskCreatedConsumer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Receipt.Dispatcher.Consumers.Fault
+{
+	public class FaultReceiptTaskCreatedConsumer : IConsumer<Fault<ReceiptTaskCreatedEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultReceiptTaskCreatedExceptionHandler _faultHandler;
+
+		public FaultReceiptTaskCreatedConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultReceiptTaskCreatedExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<ReceiptTaskCreatedEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий создания заявки по чеку"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Fault/FaultReceiptTaskCreatedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/Consumers/Fault/FaultReceiptTaskCreatedConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Receipt.Dispatcher.Consumers.Fault
+{
+	public class FaultReceiptTaskCreatedConsumerDefinition : ConsumerDefinition<FaultReceiptTaskCreatedConsumer>
+	{
+		public FaultReceiptTaskCreatedConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.receipt-task-created.consumer.receipt-dispatcher_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultReceiptTaskCreatedConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<ReceiptTaskCreatedEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/DependencyInjection.cs
@@ -44,7 +44,7 @@ namespace Edo.Receipt.Dispatcher
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/DependencyInjection.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using QS.DomainModel.UoW;
 using System.Reflection;
 using Edo.Admin;
+using Edo.Transport.Factories;
 using TrueMark.Codes.Pool;
 using TrueMark.Library;
 
@@ -26,10 +27,13 @@ namespace Edo.Receipt.Dispatcher
 			services.TryAddScoped<Tag1260Checker>();
 			services.TryAddScoped<ISaveCodesService, SaveCodesService>();
 
-			services.AddEdo();
-			services.AddEdoProblemRegistration();
-			services.AddCodesPool();
-			services.AddEdoAdminServices();
+			services
+				.AddEdo()
+				.AddEdoProblemRegistration()
+				.AddCodesPool()
+				.AddEdoAdminServices()
+				.AddFaultServices()
+				;
 
 			return services;
 		}
@@ -42,6 +46,14 @@ namespace Edo.Receipt.Dispatcher
 			{
 				cfg.AddConsumers(Assembly.GetExecutingAssembly());
 			});
+
+			return services;
+		}
+
+		public static IServiceCollection AddFaultServices(this IServiceCollection services)
+		{
+			services.TryAddScoped<FaultReceiptTaskCreatedExceptionHandler>();
+			services.TryAddScoped<IMassTransitExceptionInfoFactory, MassTransitExceptionInfoFactory>();
 
 			return services;
 		}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/FaultReceiptTaskCreatedExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Dispatcher/FaultReceiptTaskCreatedExceptionHandler.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Receipt.Dispatcher
+{
+	public class FaultReceiptTaskCreatedExceptionHandler
+	{
+		private readonly ILogger<FaultReceiptTaskCreatedExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly IGenericRepository<ReceiptEdoTask> _receiptTaskRepository;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultReceiptTaskCreatedExceptionHandler(
+			ILogger<FaultReceiptTaskCreatedExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			IGenericRepository<ReceiptEdoTask> receiptTaskRepository,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_receiptTaskRepository = receiptTaskRepository ?? throw new ArgumentNullException(nameof(receiptTaskRepository));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+		
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<ReceiptTaskCreatedEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var edoTaskId = fault.Message.ReceiptEdoTaskId;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие о создании задачи {EdoTaskId} по чеку без ошибок, пропускаем",
+					edoTaskId);
+
+				return;
+			}
+
+			ReceiptEdoTask edoTask = null;
+			
+			try
+			{
+				edoTask = _receiptTaskRepository.GetFirstOrDefault(uow, x => x.Id == edoTaskId);
+				if(edoTask is null)
+				{
+					_logger.LogWarning("Задача №{EdoTaskId} не найдена", edoTaskId);
+					return;
+				}
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события о создании задачи {EdoTaskId} по чеку",
+					edoTaskId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, ex, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Definitions/ReceiptSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Definitions/ReceiptSendConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Receipt.Sender.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<ReceiptReadyToSendEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Definitions/ReceiptSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Definitions/ReceiptSendConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Receipt.Sender.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<ReceiptReadyToSendEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Fault/FaultReceiptReadyToSendConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Fault/FaultReceiptReadyToSendConsumer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Receipt.Sender.Consumers.Fault
+{
+	public class FaultReceiptReadyToSendConsumer : IConsumer<Fault<ReceiptReadyToSendEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultReceiptReadyToSendExceptionHandler _faultHandler;
+
+		public FaultReceiptReadyToSendConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultReceiptReadyToSendExceptionHandler faultHandler
+			)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<ReceiptReadyToSendEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Обработка упавших событий о готовности чека к отправке"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Fault/FaultReceiptReadyToSendConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/Consumers/Fault/FaultReceiptReadyToSendConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Receipt.Sender.Consumers.Fault
+{
+	public class FaultReceiptReadyToSendConsumerDefinition : ConsumerDefinition<FaultReceiptReadyToSendConsumer>
+	{
+		public FaultReceiptReadyToSendConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.receipt-ready-to-send.consumer.receipt-sender_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultReceiptReadyToSendConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<Fault<ReceiptReadyToSendEvent>>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/DependencyInjection.cs
@@ -39,7 +39,7 @@ namespace Edo.Receipt.Sender
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModulKassa;
 using QS.DomainModel.UoW;
 using System.Reflection;
+using Edo.Transport.Factories;
 
 namespace Edo.Receipt.Sender
 {
@@ -22,9 +23,12 @@ namespace Edo.Receipt.Sender
 			services.TryAddScoped<FiscalDocumentFactory>();
 			services.TryAddScoped<ReceiptSender>();
 
-			services.AddEdo();
-			services.AddEdoProblemRegistration();
-			services.AddEdoAdminServices();
+			services
+				.AddEdo()
+				.AddEdoProblemRegistration()
+				.AddEdoAdminServices()
+				.AddFaultServices()
+				;
 
 			return services;
 		}
@@ -37,6 +41,14 @@ namespace Edo.Receipt.Sender
 			{
 				cfg.AddConsumers(Assembly.GetExecutingAssembly());
 			});
+
+			return services;
+		}
+
+		public static IServiceCollection AddFaultServices(this IServiceCollection services)
+		{
+			services.TryAddScoped<FaultReceiptReadyToSendExceptionHandler>();
+			services.TryAddScoped<IMassTransitExceptionInfoFactory, MassTransitExceptionInfoFactory>();
 
 			return services;
 		}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/FaultReceiptReadyToSendExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Receipt.Sender/FaultReceiptReadyToSendExceptionHandler.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Receipt.Sender
+{
+	public class FaultReceiptReadyToSendExceptionHandler
+	{
+		private readonly ILogger<FaultReceiptReadyToSendExceptionHandler> _logger;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly IGenericRepository<ReceiptEdoTask> _receiptTaskRepository;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultReceiptReadyToSendExceptionHandler(
+			ILogger<FaultReceiptReadyToSendExceptionHandler> logger,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			IGenericRepository<ReceiptEdoTask> receiptTaskRepository,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_receiptTaskRepository = receiptTaskRepository ?? throw new ArgumentNullException(nameof(receiptTaskRepository));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<ReceiptReadyToSendEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var edoTaskId = fault.Message.ReceiptEdoTaskId;
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие о готовности чека к отправке по задаче {EdoTaskId} без ошибок, пропускаем",
+					edoTaskId);
+
+				return;
+			}
+			
+			ReceiptEdoTask edoTask = null;
+
+			try
+			{
+				edoTask = _receiptTaskRepository.GetFirstOrDefault(uow, x => x.Id == edoTaskId);
+				
+				if(edoTask is null)
+				{
+					_logger.LogWarning("Задача №{EdoTaskId} не найдена", edoTaskId);
+					return;
+				}
+				
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события о готовности чека к отправке по задаче {EdoTaskId}",
+					edoTaskId);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, edoTask, ex, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Scheduler/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Scheduler/DependencyInjection.cs
@@ -33,7 +33,7 @@ namespace Edo.Scheduler
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Definitions/TransferDocumentAcceptedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Definitions/TransferDocumentAcceptedConsumerDefinition.cs
@@ -19,8 +19,8 @@ namespace Edo.Transfer.Dispatcher.Consumers.Definitions
 			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
-
 				rmq.Bind<TransferDocumentAcceptedEvent>();
+				rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Definitions/TransferDocumentAcceptedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Definitions/TransferDocumentAcceptedConsumerDefinition.cs
@@ -20,7 +20,7 @@ namespace Edo.Transfer.Dispatcher.Consumers.Definitions
 			{
 				rmq.ExchangeType = ExchangeType.Fanout;
 				rmq.Bind<TransferDocumentAcceptedEvent>();
-				rmq.DiscardFaultedMessages();
+				//rmq.DiscardFaultedMessages();
 			}
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Fault/FaultTransferDocumentAcceptedConsumer.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Fault/FaultTransferDocumentAcceptedConsumer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Documents;
+using MassTransit;
+using QS.DomainModel.UoW;
+
+namespace Edo.Transfer.Dispatcher.Consumers.Fault
+{
+	public class FaultTransferDocumentAcceptedConsumer : IConsumer<Fault<TransferDocumentAcceptedEvent>>
+	{
+		private readonly IUnitOfWorkFactory _uowFactory;
+		private readonly FaultTransferDocumentAcceptedExceptionHandler _faultHandler;
+
+		public FaultTransferDocumentAcceptedConsumer(
+			IUnitOfWorkFactory uowFactory,
+			FaultTransferDocumentAcceptedExceptionHandler faultHandler)
+		{
+			_uowFactory = uowFactory ?? throw new ArgumentNullException(nameof(uowFactory));
+			_faultHandler = faultHandler ?? throw new ArgumentNullException(nameof(faultHandler));
+		}
+		
+		public async Task Consume(ConsumeContext<Fault<TransferDocumentAcceptedEvent>> context)
+		{
+			var fault = context.Message;
+
+			using(var uow = _uowFactory.CreateWithoutRoot("Сервис обработки упавших событий подтверждения трансфера"))
+			{
+				await _faultHandler.HandleAsync(uow, fault, context.CancellationToken);
+				await Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Fault/FaultTransferDocumentAcceptedConsumerDefinition.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/Consumers/Fault/FaultTransferDocumentAcceptedConsumerDefinition.cs
@@ -1,0 +1,26 @@
+﻿using Edo.Contracts.Messages.Events;
+using MassTransit;
+using RabbitMQ.Client;
+
+namespace Edo.Transfer.Dispatcher.Consumers.Fault
+{
+	public class FaultTransferDocumentAcceptedConsumerDefinition : ConsumerDefinition<FaultTransferDocumentAcceptedConsumer>
+	{
+		public FaultTransferDocumentAcceptedConsumerDefinition()
+		{
+			Endpoint(x => x.Name = "edo.transfer-document-accepted.consumer.transfer-dispatcher_fault");
+		}
+
+		protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+			IConsumerConfigurator<FaultTransferDocumentAcceptedConsumer> consumerConfigurator)
+		{
+			endpointConfigurator.ConfigureConsumeTopology = false;
+
+			if(endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rmq)
+			{
+				rmq.ExchangeType = ExchangeType.Fanout;
+				rmq.Bind<TransferDocumentAcceptedEvent>();
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/DependencyInjection.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using QS.DomainModel.UoW;
 using System.Reflection;
+using Edo.Documents;
+using Edo.Transport.Factories;
 
 namespace Edo.Transfer.Dispatcher
 {
@@ -21,6 +23,7 @@ namespace Edo.Transfer.Dispatcher
 				.AddEdo()
 				.AddEdoTransfer()
 				.AddEdoProblemRegistration()
+				.AddFaultServices()
 				;
 
 			return services;
@@ -35,6 +38,14 @@ namespace Edo.Transfer.Dispatcher
 				cfg.AddConsumers(Assembly.GetExecutingAssembly());
 			});
 
+			return services;
+		}
+
+		public static IServiceCollection AddFaultServices(this IServiceCollection services)
+		{
+			services.TryAddScoped<FaultTransferDocumentAcceptedExceptionHandler>();
+			services.TryAddScoped<IMassTransitExceptionInfoFactory, MassTransitExceptionInfoFactory>();
+			
 			return services;
 		}
 	}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/DependencyInjection.cs
@@ -35,7 +35,7 @@ namespace Edo.Transfer.Dispatcher
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/FaultTransferDocumentAcceptedExceptionHandler.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Dispatcher/FaultTransferDocumentAcceptedExceptionHandler.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Edo.Contracts.Messages.Events;
+using Edo.Problems;
+using Edo.Transport.Factories;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using QS.DomainModel.UoW;
+using Vodovoz.Core.Domain.Edo;
+using Vodovoz.Core.Domain.Repositories;
+
+namespace Edo.Documents
+{
+	public class FaultTransferDocumentAcceptedExceptionHandler
+	{
+		private readonly ILogger<FaultTransferDocumentAcceptedExceptionHandler> _logger;
+		private readonly IGenericRepository<TransferEdoTask> _transferTaskRepository;
+		private readonly IMassTransitExceptionInfoFactory _exceptionInfoFactory;
+		private readonly FaultEdoProblemRegistrar _problemRegistrar;
+
+		public FaultTransferDocumentAcceptedExceptionHandler(
+			ILogger<FaultTransferDocumentAcceptedExceptionHandler> logger,
+			IGenericRepository<TransferEdoTask> transferTaskRepository,
+			IMassTransitExceptionInfoFactory exceptionInfoFactory,
+			FaultEdoProblemRegistrar problemRegistrar
+		)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			_transferTaskRepository = transferTaskRepository ?? throw new ArgumentNullException(nameof(transferTaskRepository));
+			_exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
+			_problemRegistrar = problemRegistrar ?? throw new ArgumentNullException(nameof(problemRegistrar));
+		}
+		
+		public async Task HandleAsync(
+			IUnitOfWork uow,
+			Fault<TransferDocumentAcceptedEvent> fault,
+			CancellationToken cancellationToken
+		)
+		{
+			var documentId = fault.Message.DocumentId;
+			
+			if(!fault.Exceptions.Any())
+			{
+				_logger.LogInformation(
+					"Упавшее событие подтверждения трансфера по документу {TransferDocumentId} без ошибок, пропускаем",
+					documentId);
+				
+				return;
+			}
+
+			IEnumerable<int> orderTaskIds = null;
+			
+			try
+			{
+				var transferTasks = await _transferTaskRepository
+					.GetAsync(uow, x => x.Id == documentId, cancellationToken: cancellationToken);
+				
+				var transferTask = transferTasks.Value.FirstOrDefault();
+
+				if(transferTask is null)
+				{
+					_logger.LogWarning("Не обнаружена задача по трансферу для документа трансфера №{TransferDocumentId}", documentId);
+					return;
+				}
+				
+				if(transferTask.Status == EdoTaskStatus.Completed)
+				{
+					_logger.LogWarning("При обработке принятия документа трансфера №{documentId} обнаружено, что трансфер уже завершен", documentId);
+					return;
+				}
+				
+				orderTaskIds = transferTask.TransferEdoRequests
+					.Select(x => x.Iteration.OrderEdoTask.Id)
+					.Distinct();
+				
+				//TODO может нужно проверять еще и таски на возможность перевода в проблему
+				var exceptionInfos = _exceptionInfoFactory.Create(fault.Exceptions);
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, orderTaskIds, exceptionInfos, cancellationToken);
+			}
+			catch(Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Ошибка при обработке упавшего события подтверждения трансфера по документу {TransferDocumentId}",
+					documentId);
+				
+				await _problemRegistrar.TryRegisterExceptionProblem(uow, orderTaskIds, new []{ _exceptionInfoFactory.Create(ex) }, cancellationToken);
+			}
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Sender/DependencyInjection.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transfer.Sender/DependencyInjection.cs
@@ -30,7 +30,7 @@ namespace Edo.Transfer.Dispatcher
 
 			services.AddEdoMassTransit(configureBus: cfg =>
 			{
-				cfg.AddConsumers(Assembly.GetExecutingAssembly());
+				cfg.AddConsumers(x => !x.ToString().Contains("Fault"), Assembly.GetExecutingAssembly());
 			});
 
 			return services;

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transport/Factories/IMassTransitExceptionInfoFactory.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transport/Factories/IMassTransitExceptionInfoFactory.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using Edo.Problems.Exception;
+using MassTransit;
+
+namespace Edo.Transport.Factories
+{
+	/// <summary>
+	/// Фабрика информации об исключении
+	/// </summary>
+	public interface IMassTransitExceptionInfoFactory
+	{
+		/// <summary>
+		/// Получение списка данных по исключениям из <see cref="ExceptionInfo"/>
+		/// </summary>
+		/// <param name="exceptionInfos">Данные по ошибкам</param>
+		/// <returns></returns>
+		IEnumerable<MassTransitExceptionInfo> Create(IEnumerable<ExceptionInfo> exceptionInfos);
+		/// <summary>
+		/// Получение информации об исключении из самой ошибки
+		/// </summary>
+		/// <param name="exception">Ошибка</param>
+		/// <returns></returns>
+		MassTransitExceptionInfo Create(Exception exception);
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transport/Factories/MassTransitExceptionInfoFactory.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transport/Factories/MassTransitExceptionInfoFactory.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Edo.Problems.Exception;
+using MassTransit;
+
+namespace Edo.Transport.Factories
+{
+	/// <inheritdoc/>
+	public class MassTransitExceptionInfoFactory : IMassTransitExceptionInfoFactory
+	{
+		/// <inheritdoc/>
+		public IEnumerable<MassTransitExceptionInfo> Create(IEnumerable<ExceptionInfo> exceptionInfos)
+		{
+			return exceptionInfos
+				.Select(Create)
+				.ToList();
+		}
+
+		/// <inheritdoc/>
+		public MassTransitExceptionInfo Create(Exception exception)
+		{
+			if(exception is null)
+			{
+				return null;
+			}
+			
+			var exceptionInfo = new MassTransitExceptionInfo
+			{
+				Message = exception.Message,
+				ExceptionType = exception.GetType().Name,
+				Source = exception.Source,
+				StackTrace = exception.StackTrace,
+				Data = new Dictionary<string, object>(),
+				InnerException = Create(exception.InnerException)
+			};
+				
+			return exceptionInfo;
+		}
+
+		private MassTransitExceptionInfo Create(ExceptionInfo exceptionInfo)
+		{
+			if(exceptionInfo is null)
+			{
+				return null;
+			}
+			
+			var info = new MassTransitExceptionInfo
+			{
+				Message = exceptionInfo.Message,
+				ExceptionType = exceptionInfo.ExceptionType,
+				Source = exceptionInfo.Source,
+				StackTrace = exceptionInfo.StackTrace,
+				Data = exceptionInfo.Data,
+				InnerException = Create(exceptionInfo.InnerException)
+			};
+
+			return info;
+		}
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transport/MassTransitExceptionInfo.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transport/MassTransitExceptionInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace Edo.Problems.Exception
+{
+	public class MassTransitExceptionInfo
+	{
+		/// <summary>
+		/// The type name of the exception
+		/// </summary>
+		public string ExceptionType { get; set; }
+
+		/// <summary>
+		/// The inner exception if present (also converted to ExceptionInfo)
+		/// </summary>
+		public MassTransitExceptionInfo InnerException { get; set; }
+
+		/// <summary>
+		/// The stack trace of the exception site
+		/// </summary>
+		public string StackTrace { get; set; }
+
+		/// <summary>
+		/// The exception message
+		/// </summary>
+		public string Message { get; set; }
+
+		/// <summary>
+		/// The exception source
+		/// </summary>
+		public string Source { get; set; }
+
+		public IDictionary<string, object> Data { get; set; }
+	}
+}

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transport/TransportConfiguration.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transport/TransportConfiguration.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using RabbitMQ.Client;
 using System;
 using System.Net.Security;
+using System.Reflection;
 using System.Security.Authentication;
 using Edo.Contracts.Messages.Events;
 using Vodovoz.Settings.Pacs;
@@ -306,7 +307,6 @@ namespace Edo.Transport
 					});
 
 					rabbitCfg.AddEdoTopology(context);
-
 					configureRabbit?.Invoke(context, rabbitCfg);
 
 					rabbitCfg.ConfigureEndpoints(context);

--- a/Source/Libraries/Core/Backend/Edo/Edo.Transport/TransportConfiguration.cs
+++ b/Source/Libraries/Core/Backend/Edo/Edo.Transport/TransportConfiguration.cs
@@ -68,7 +68,6 @@ namespace Edo.Transport
 				x.Durable = true;
 				x.AutoDelete = false;
 			});
-
 			
 			cfg.Message<TransferDocumentAcceptedEvent>(x => x.SetEntityName("edo.transfer-document-accepted.publish"));
 			cfg.Publish<TransferDocumentAcceptedEvent>(x =>

--- a/Source/Libraries/Core/Business/Vodovoz.Core.Data.NHibernate/Repositories/GenericRepository.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Core.Data.NHibernate/Repositories/GenericRepository.cs
@@ -86,6 +86,7 @@ namespace Vodovoz.Infrastructure.Persistance
 		}
 
 		/// <inheritdoc/>
+		//TODO нет тут никакого Result, надо переделать
 		public async Task<Result<IEnumerable<TEntity>>> GetAsync(
 			IUnitOfWork unitOfWork,
 			Expression<Func<TEntity, bool>> predicate = null,
@@ -113,6 +114,7 @@ namespace Vodovoz.Infrastructure.Persistance
 		}
 
 		/// <inheritdoc/>
+		//TODO нет тут никакого Result, надо переделать
 		public async Task<Result<IEnumerable<TEntity>>> GetAsync(
 			IUnitOfWork unitOfWork,
 			ExpressionSpecification<TEntity> expressionSpecification,

--- a/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/CustomEdoTaskProblem.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/CustomEdoTaskProblem.cs
@@ -12,5 +12,13 @@ namespace Vodovoz.Core.Domain.Edo
 			get => _customMessage;
 			set => SetField(ref _customMessage, value);
 		}
+
+		public static CustomEdoTaskProblem Create(string sourceName, EdoTask task, string message) =>
+			new CustomEdoTaskProblem
+			{
+				SourceName = sourceName,
+				EdoTask = task,
+				CustomMessage = message
+			};
 	}
 }

--- a/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/EdoTask.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/EdoTask.cs
@@ -74,5 +74,16 @@ namespace Vodovoz.Core.Domain.Edo
 			get => _cancellationReason;
 			set => SetField(ref _cancellationReason, value);
 		}
+
+		/// <summary>
+		/// Обновление статуса таски по типу проблемы
+		/// </summary>
+		/// <param name="problemImportance">Тип проблемы</param>
+		public virtual void UpdateStatusByEdoProblemImportance(EdoProblemImportance problemImportance)
+		{
+			Status = problemImportance == EdoProblemImportance.Problem
+				? EdoTaskStatus.Problem
+				: EdoTaskStatus.Waiting;
+		}
 	}
 }

--- a/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/ExceptionEdoTaskProblem.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/ExceptionEdoTaskProblem.cs
@@ -12,5 +12,13 @@
 			get => _exceptionMessage;
 			set => SetField(ref _exceptionMessage, value);
 		}
+
+		public static ExceptionEdoTaskProblem Create(string sourceName, EdoTask task, string message) =>
+			new ExceptionEdoTaskProblem
+			{
+				SourceName = sourceName,
+				EdoTask = task,
+				ExceptionMessage = message
+			};
 	}
 }

--- a/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/OutgoingEdoDocument.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/OutgoingEdoDocument.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Vodovoz.Core.Domain.Edo
 {
-	public class OutgoingEdoDocument : PropertyChangedBase
+	public class OutgoingEdoDocument : PropertyChangedBase, IDomainObject
 	{
 		private int _id;
 		private DateTime _creationTime;

--- a/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/TransferEdoRequestIteration.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Core.Domain/Edo/TransferEdoRequestIteration.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Vodovoz.Core.Domain.Edo
 {
-	public class TransferEdoRequestIteration : PropertyChangedBase
+	public class TransferEdoRequestIteration : PropertyChangedBase, IDomainObject
     {
         private int _id;
         private DateTime _time;


### PR DESCRIPTION
добавлены консьюмеры и обработчики нескольких ЭДО этапов, для обработки падений. Консьюмеры лучше подключать без definition, т.к. не получилось настроить путь для transferCompleted из-за direct exchange